### PR TITLE
fix: correct outlook mailer module import and export

### DIFF
--- a/mailer/outlook/index.js
+++ b/mailer/outlook/index.js
@@ -1,5 +1,3 @@
-const { sendEmail } = require('send');
+const sendEmail = require('./send');
 
-module.exports = {
-    sendEmail
-}
+module.exports = sendEmail;


### PR DESCRIPTION
## Summary

`mailer/outlook/index.js` failed to load:

- It did `require('send')`, referencing a non-existent npm package instead of the local `./send` file (`Cannot find module 'send'`).
- It destructured `{ sendEmail }`, but `send.js` exports the function directly (`module.exports = sendEmail`), so the destructured value would have been `undefined` even if the require had resolved.

## Change

- Require the local `./send` file.
- Re-export the function directly, matching the documented usage:
  ```js
  const sendEmail = require('jwz/mailer/outlook/send');
  sendEmail(sender, password, receiver, subject, text);
  ```

## Verification

Loading the module now returns a callable function, and invoking it sends through `send.js` as expected (verified with a stubbed `nodemailer`).

The companion documentation fix is in jwz-website (`fix/mailer-export`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01148Fa4o7J1t3jtiNVDuoT5)_