### PR TITLE
docs: add project overview and point to documentation website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,32 @@
 [![Npm Website](https://img.shields.io/npm/v/jwz?style=flat&logo=npm)](https://www.npmjs.com/package/jwz)
 
-# Information
+# jwz
 
-This project is created for using the API with Git platforms to build, delete, invite, release, remove, and more.
+## Overview
+
+jwz is a Node.js utility package that wraps several common APIs behind one consistent interface, so you can automate routine work without rewriting the same boilerplate in every project.
+
+It groups its utilities into three areas:
+
+* **Git platforms:** build, delete, invite, release, and remove operations for GitHub and GitLab.
+* **AI providers:** clients for DeepSeek, OpenAI, and OpenRouter.
+* **Mailer:** sending email through Outlook.
+
+## Install
+
+```sh
+npm install jwz
+```
 
 ## Supported Platforms
 | [GitHub](https://github.com)
 | [GitLab](https://gitlab.com) |
 
-The available functions can be accessed at this [website](https://jetsadawijit.github.io/jwz-website/).
+## Full Documentation
+
+This page is only a short overview. To understand the project fully, including every available module, function, parameter, and usage example, please read the project website:
+
+**https://jetsadawijit.github.io/jwz-website/**
 
 # `Member`
 


### PR DESCRIPTION
## Summary

Rewrites the README so a new reader can understand the project at a glance and knows where to go for the full details.

* Adds an **Overview** describing jwz as a Node.js utility package and its three areas: Git platform utilities (GitHub, GitLab), AI provider clients (DeepSeek, OpenAI, OpenRouter), and the Outlook mailer.
* Adds an **Install** snippet.
* Adds a prominent **Full Documentation** section that sends readers to the website for complete module, function, and usage details.
* Keeps the existing npm badge, supported platforms, and member table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNrcnizdmoybc3oBpVJkBp)_