### PR TITLE
fix(mailer): upgrade nodemailer to 9.0.1 to close raw file and url access bypass

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^1.6.2",
-    "nodemailer": "^8.0.7"
+    "nodemailer": "^9.0.1"
   }
 }


### PR DESCRIPTION
## Verdict: the reported vulnerability is REAL, and already fixed upstream in nodemailer 9.0.1

### What was claimed
nodemailer's `MailComposer.compile()` builds the `raw` message root node without threading `disableFileAccess` / `disableUrlAccess`, while every other content node builder does. A `raw: { path }` or `raw: { href }` message therefore bypasses those sandbox flags and reads a local file (or fetches a URL) into the actual sent message.

### Verification (no network, local only)
* **Code read** of the installed `nodemailer@8.0.11`:
  * `lib/mail-composer/index.js:35` builds the raw node with `{ newline }` only; the sibling builders (`_createMixed` / `_createAlternative` / `_createRelated` / `_createContentNode`) all pass both flags.
  * `lib/mime-node/index.js:51-52` derives the flags solely from the node's own options (no inheritance); `_getStream` guards file read (`:985`) and URL fetch (`:999`) only by those flags.
* **PoC** (file case, temp file only): attachment `{path}` with `disableFileAccess: true` is correctly **BLOCKED (EFILEACCESS)**, but `raw: {path}` with the same flag **leaks the file content into the composed message** — confirming the asymmetry.
* **Upstream diff**: `9.0.0` is still vulnerable at line 35; `9.0.1` threads `disableUrlAccess` / `disableFileAccess` onto the raw node — exactly the report's recommended remediation.

### Why this matters for jwz
jwz's own mailer wrapper (`src/mailer/outlook/send.js`) only passes `{ from, to, subject, text }` and never sets the sandbox flags, so jwz's public API is not directly exploitable. However, jwz's dependency range `^8.0.7` resolves to `8.0.11`, which ships the vulnerable code; the fix exists only in `9.0.1`.

### The fix
Bump `nodemailer` from `^8.0.7` to `^9.0.1` to pull in the upstream patch.

After the bump, re-running the PoC shows `raw: {path}` is now **BLOCKED (EFILEACCESS)** — the bypass is closed. jwz uses only the stable `createTransport` / `sendMail` API (unchanged across 8 to 9), and the mailer wrapper was verified to still load on v9.

Note: this is a major version bump (8 to 9). The maintainer has previously merged a nodemailer major bump (7 to 8), and jwz's usage relies only on the stable core API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNrcnizdmoybc3oBpVJkBp)_